### PR TITLE
make RdbmsSpecifics public

### DIFF
--- a/src-jdbc4/net/sf/log4jdbc/RdbmsSpecifics.java
+++ b/src-jdbc4/net/sf/log4jdbc/RdbmsSpecifics.java
@@ -24,7 +24,7 @@ import java.text.SimpleDateFormat;
  *
  * @author Arthur Blake
  */
-class RdbmsSpecifics
+public class RdbmsSpecifics
 {
   /**
    * Default constructor.


### PR DESCRIPTION
I try to use log4jdbc with spring, but I don't want to change my url style. So I use AOP, here is my Interceptor
```
public class DataSourceSpyInterceptor implements MethodInterceptor {

    private RdbmsSpecifics rdbmsSpecifics = null;

    private RdbmsSpecifics getRdbmsSpecifics(Connection conn) {
        if(rdbmsSpecifics == null) {
            rdbmsSpecifics = DriverSpy.getRdbmsSpecifics(conn);
        }
        return rdbmsSpecifics;
    }

    public Object invoke(MethodInvocation invocation) throws Throwable {
        Object result = invocation.proceed();
        if(SpyLogFactory.getSpyLogDelegator().isJdbcLoggingEnabled()) {
            if(result instanceof Connection) {
                Connection conn = (Connection)result;
                return new ConnectionSpy(conn,DriverSpy.getRdbmsSpecifics(conn));
            }
        }
        return result;
    }
}
```
and this is how I config in Spring 
```
<bean id="log4jdbcInterceptor" class="net.sf.log4jdbc.DataSourceSpyInterceptor" />

    <bean id="dataSourceLog4jdbcAutoProxyCreator" class="org.springframework.aop.framework.autoproxy.BeanNameAutoProxyCreator">
        <property name="interceptorNames">
            <list>
                <value>log4jdbcInterceptor</value>
            </list>
        </property>
        <property name="beanNames">
            <list>
                <value>verticaDS</value>
                <value>mysqlDS</value>
            </list>
        </property>
    </bean>
```

But my Interceptor should be in the net.sf.log4jdbc package since the class RdbmsSpecifics is not public, so I think it is better to make it public.


