### PR TITLE
Enable monitoring with markers and original query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+classes-jdbc4/net/sf/*
+build/*
+.idea/*

--- a/src-jdbc4/net/sf/log4jdbc/DriverSpy.java
+++ b/src-jdbc4/net/sf/log4jdbc/DriverSpy.java
@@ -182,6 +182,9 @@ public class DriverSpy implements Driver
 	static boolean DumpSqlDelete;
 	static boolean DumpSqlCreate;
 
+	static boolean reportOriginalSql;
+	static boolean shouldUseMarkersForTimingReports;
+
 	// only true if one ore more of the above 4 flags are false.
 	static boolean DumpSqlFilteringOn;
 
@@ -414,6 +417,8 @@ public class DriverSpy implements Driver
 			SqlTimingErrorThresholdMsec = thresh.longValue();
 		}
 
+		shouldUseMarkersForTimingReports = getBooleanOption(props, "log4jdbc.sqltiming.usemarkersfortimingreports", false);
+
 		DumpBooleanAsTrueFalse = getBooleanOption(props,
 			"log4jdbc.dump.booleanastruefalse", false);
 
@@ -431,6 +436,7 @@ public class DriverSpy implements Driver
 		DumpSqlUpdate = getBooleanOption(props, "log4jdbc.dump.sql.update", true);
 		DumpSqlDelete = getBooleanOption(props, "log4jdbc.dump.sql.delete", true);
 		DumpSqlCreate = getBooleanOption(props, "log4jdbc.dump.sql.create", true);
+		reportOriginalSql = getBooleanOption(props, "log4jdbc.dump.sql.reportoriginal", false);
 
 		DumpSqlFilteringOn = !(DumpSqlSelect && DumpSqlInsert && DumpSqlUpdate &&
 			DumpSqlDelete && DumpSqlCreate);

--- a/src-jdbc4/net/sf/log4jdbc/PreparedStatementSpy.java
+++ b/src-jdbc4/net/sf/log4jdbc/PreparedStatementSpy.java
@@ -106,6 +106,10 @@ public class PreparedStatementSpy extends StatementSpy implements PreparedStatem
 
   protected String dumpedSql()
   {
+    if (DriverSpy.reportOriginalSql) {
+      return sql;
+    }
+
     StringBuffer dumpSql = new StringBuffer();
     int lastPos = 0;
     int Qpos = sql.indexOf('?', lastPos);  // find position of first question mark


### PR DESCRIPTION
Added 2 configurations:
`log4jdbc.sqltiming.usemarkersfortimingreports` - when set to true uses markers to log the timing of the queries. Default value is false.
`log4jdbc.dump.sql.reportoriginal` - when set to true, keeps the original sql query without replacing the `?` signs

Also added a static property `Slf4jSpyLogDelegator.markerFactory` to enable for custom marker creations for plugins such as [logstash-logback-encoder](https://github.com/logstash/logstash-logback-encoder) that have their own marker objects.

This PR should close the issue #91 
