### PR TITLE
Create Maven pom.xml file to enable automatic build via e.g. jitpack.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>net.sf</groupId>
+  <artifactId>log4jdbc</artifactId>
+  <version>1.2.0</version>
+  <url>https://github.com/arthurblake/log4jdbc</url>
+  <packaging>jar</packaging>
+  
+  <properties>
+    <maven.plugin.compiler.version>3.13.0</maven.plugin.compiler.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <slf4j.version>2.0.7</slf4j.version>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src-jdbc4</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>src-jdbc4</directory>
+        <excludes>
+          <exclude>**/*.java</exclude>
+        </excludes>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven.plugin.compiler.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <repositories>
+    <repository>
+      <id>Maven Repo</id>
+      <url>https://mvnrepository.com/artifact/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+</project>


### PR DESCRIPTION
The pom.xml file compiles to Java 21 version. JDK version may be set to lower level if compatible - I have not checked that. JDK version can be set in properties section.

Furthermore, dependency to slf4j-api has been added. Version to include can be configured in properties section.

Also, current Maven compiler plugin is used (as of pom.xml creation this was 3.13.0) but version can be configured in properties section as well.

Original author may add license section as well.